### PR TITLE
pypy3.8 upgrade

### DIFF
--- a/requirements/develop.pip
+++ b/requirements/develop.pip
@@ -3,6 +3,7 @@ pytest>=4.0.0
 pytest-cov
 pytest-mock
 pytest-sugar
+pytest-xdist
 flake8
 wheel
 # Fixes those godamn pip erros

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,12 @@ universal = 1
 
 [tool:pytest]
 mock_use_standalone_module = true
+markers =
+    all_pythons
+    asdf_error
+    asdf_missing
+    asdf_python_missing
+    pythons
 
 [flake8]
 max-line-length = 100

--- a/tests/test_asdf.py
+++ b/tests/test_asdf.py
@@ -9,75 +9,85 @@ class TestAsdfGetInstalled:
     @pytest.mark.asdf_missing
     def test_asdf_missing(self, asdf):
         with pytest.raises(plugin.AsdfMissing):
-            plugin.asdf_get_installed('3.6')
+            plugin.asdf_get_installed("3.6")
 
     @pytest.mark.asdf_python_missing
     def test_asdf_python_plugin_missing(self, asdf):
         with pytest.raises(plugin.AsdfPluginMissing):
-            plugin.asdf_get_installed('3.6')
+            plugin.asdf_get_installed("3.6")
 
-    @pytest.mark.asdf_error(42, 'Unknown error')
+    @pytest.mark.asdf_error(42, "Unknown error")
     def test_unknown_error(self, asdf):
         with pytest.raises(plugin.AsdfError):
-            plugin.asdf_get_installed('3.6')
+            plugin.asdf_get_installed("3.6")
 
-    @pytest.mark.pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_return_python_binary_path(self, asdf):
-        assert plugin.asdf_get_installed('3.6') == '3.6.0'
+        assert plugin.asdf_get_installed("3.6") == "3.6.0"
 
-    @pytest.mark.pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_return_pypy_python_binary_path(self, asdf):
-        assert plugin.asdf_get_installed('pypy2.7') == 'pypy2.7-6.0.0'
+        assert plugin.asdf_get_installed("pypy2.7") == "pypy2.7-6.0.0"
 
-    @pytest.mark.pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.pythons(
+        "2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.5-6.0.0", "pypy3.8-7.0.0"
+    )
+    def test_return_pypy3_5_python_binary_path(self, asdf):
+        assert plugin.asdf_get_installed("pypy3.5") == "pypy3.5-6.0.0"
+
+    @pytest.mark.pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_return_pypy3_python_binary_path(self, asdf):
-        assert plugin.asdf_get_installed('pypy3.5') == 'pypy3.5-6.0.0'
+        assert plugin.asdf_get_installed("pypy3.8") == "pypy3.8-7.0.0"
 
-    @pytest.mark.pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_rely_on_best_version(self, asdf, mocker):
-        best_version = mocker.patch.object(plugin, 'best_version', return_value='result')
-        assert plugin.asdf_get_installed('3.6') == 'result'
-        best_version.assert_called_once_with('3.6', mocker.ANY)
+        best_version = mocker.patch.object(
+            plugin, "best_version", return_value="result"
+        )
+        assert plugin.asdf_get_installed("3.6") == "result"
+        best_version.assert_called_once_with("3.6", mocker.ANY)
 
     def test_return_none_if_no_python(self, asdf):
-        assert plugin.asdf_get_installed('3.6') is None
+        assert plugin.asdf_get_installed("3.6") is None
 
 
 class TestAsdfWhich:
     def test_matching_version(self, asdf):
-        assert plugin.asdf_which('3.6.0') == asdf.python_bin('3.6.0')
+        assert plugin.asdf_which("3.6.0") == asdf.python_bin("3.6.0")
 
-    @pytest.mark.asdf_error(42, 'Unknown error')
+    @pytest.mark.asdf_error(42, "Unknown error")
     def test_error(self, asdf):
         with pytest.raises(plugin.AsdfError):
-            plugin.asdf_which('3.6.0')
+            plugin.asdf_which("3.6.0")
 
 
 class TestAsdfInstall:
-    @pytest.mark.asdf_error('list-all', 42, 'Unknown error')
+    @pytest.mark.asdf_error("list-all", 42, "Unknown error")
     def test_list_all_error(self, asdf):
         with pytest.raises(plugin.AsdfError):
-            plugin.asdf_install('3.6')
+            plugin.asdf_install("3.6")
 
-    @pytest.mark.asdf_error('install', 42, 'Unknown error')
+    @pytest.mark.asdf_error("install", 42, "Unknown error")
     def test_install_error(self, asdf):
         with pytest.raises(plugin.AsdfError):
-            plugin.asdf_install('3.6')
+            plugin.asdf_install("3.6")
 
-    @pytest.mark.all_pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.all_pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_install_python(self, asdf):
-        assert plugin.asdf_install('3.6') == '3.6.0'
+        assert plugin.asdf_install("3.6") == "3.6.0"
 
-    @pytest.mark.all_pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.all_pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_install_pypy(self, asdf):
-        assert plugin.asdf_install('pypy2.7') == 'pypy2.7-6.0.0'
+        assert plugin.asdf_install("pypy2.7") == "pypy2.7-6.0.0"
 
-    @pytest.mark.all_pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.all_pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_install_pypy3(self, asdf):
-        assert plugin.asdf_install('pypy3.5') == 'pypy3.5-6.0.0'
+        assert plugin.asdf_install("pypy3") == "pypy3.8-7.0.0"
 
-    @pytest.mark.all_pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.all_pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_rely_on_best_version(self, asdf, mocker):
-        best_version = mocker.patch.object(plugin, 'best_version', return_value='result')
-        assert plugin.asdf_install('3.6') == 'result'
-        best_version.assert_called_once_with('3.6', mocker.ANY)
+        best_version = mocker.patch.object(
+            plugin, "best_version", return_value="result"
+        )
+        assert plugin.asdf_install("3.6") == "result"
+        best_version.assert_called_once_with("3.6", mocker.ANY)

--- a/tests/test_tox_python_executable.py
+++ b/tests/test_tox_python_executable.py
@@ -6,8 +6,9 @@ from tox_asdf import plugin
 
 
 class EnvConfig(object):
-    '''A mock envconfig'''
-    def __init__(self, basepython='python3.6'):
+    """A mock envconfig"""
+
+    def __init__(self, basepython="python3.6"):
         self.basepython = basepython
 
 
@@ -24,60 +25,60 @@ class TestToxGetPythonExecutable:
         assert python is None
         LOG.error.assert_called_once()
 
-    @pytest.mark.asdf_error(42, 'Unknown error')
+    @pytest.mark.asdf_error(42, "Unknown error")
     def test_asdf_unknown_error(self, asdf, LOG):
         python = plugin.tox_get_python_executable(EnvConfig())
         assert python is None
         LOG.error.assert_called_once()
 
-    @pytest.mark.asdf_error('list', 42, 'Unknown error')
+    @pytest.mark.asdf_error("list", 42, "Unknown error")
     def test_asdf_list_error(self, asdf, LOG):
         python = plugin.tox_get_python_executable(EnvConfig())
         assert python is None
         LOG.error.assert_called_once()
 
-    @pytest.mark.pythons('3.6.0')
-    @pytest.mark.asdf_error('where', 42, 'Unknown error')
+    @pytest.mark.pythons("3.6.0")
+    @pytest.mark.asdf_error("where", 42, "Unknown error")
     def test_asdf_where_error(self, asdf, LOG):
         python = plugin.tox_get_python_executable(EnvConfig())
         assert python is None
         LOG.error.assert_called_once()
 
     def test_basepython_is_not_python(self):
-        envconfig = EnvConfig('*TEST*')
+        envconfig = EnvConfig("*TEST*")
         python = plugin.tox_get_python_executable(envconfig)
         assert python is None
 
     def test_return_none_if_no_python(self, asdf):
         assert plugin.tox_get_python_executable(EnvConfig()) is None
 
-    @pytest.mark.all_pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.all_pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_install_python_if_no_python_but_flag(self, asdf, CFG):
         CFG.install = True
         python = plugin.tox_get_python_executable(EnvConfig())
-        assert python == asdf.python_bin('3.6.0')
+        assert python == asdf.python_bin("3.6.0")
 
-    @pytest.mark.all_pythons('2.7.15', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.all_pythons("2.7.15", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_install_python_but_return_none_if_no_match(self, asdf, CFG):
         CFG.install = True
         assert plugin.tox_get_python_executable(EnvConfig()) is None
 
-    @pytest.mark.pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_return_python_binary_path(self, asdf):
         python = plugin.tox_get_python_executable(EnvConfig())
-        assert python == asdf.python_bin('3.6.0')
+        assert python == asdf.python_bin("3.6.0")
 
-    @pytest.mark.pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_return_pypy_python_binary_path(self, asdf):
-        envconfig = EnvConfig('pypy')
+        envconfig = EnvConfig("pypy")
         python = plugin.tox_get_python_executable(envconfig)
-        assert python == asdf.python_bin('pypy2.7-6.0.0')
+        assert python == asdf.python_bin("pypy2.7-6.0.0")
 
-    @pytest.mark.pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_return_pypy3_python_binary_path(self, asdf):
-        envconfig = EnvConfig('pypy3')
+        envconfig = EnvConfig("pypy3")
         python = plugin.tox_get_python_executable(envconfig)
-        assert python == asdf.python_bin('pypy3.5-6.0.0')
+        assert python == asdf.python_bin("pypy3.8-7.0.0")
 
 
 class TestToxGetPythonExecutableNoFallback:
@@ -97,58 +98,58 @@ class TestToxGetPythonExecutableNoFallback:
             plugin.tox_get_python_executable(EnvConfig())
         LOG.error.assert_called_once()
 
-    @pytest.mark.asdf_error(42, 'Unknown error')
+    @pytest.mark.asdf_error(42, "Unknown error")
     def test_asdf_unknown_error(self, asdf, LOG):
         with pytest.raises(plugin.AsdfError):
             plugin.tox_get_python_executable(EnvConfig())
         LOG.error.assert_called_once()
 
-    @pytest.mark.asdf_error('list', 42, 'Unknown error')
+    @pytest.mark.asdf_error("list", 42, "Unknown error")
     def test_asdf_list_error(self, asdf, LOG):
         with pytest.raises(plugin.AsdfError):
             plugin.tox_get_python_executable(EnvConfig())
         LOG.error.assert_called_once()
 
-    @pytest.mark.pythons('3.6.0')
-    @pytest.mark.asdf_error('where', 42, 'Unknown error')
+    @pytest.mark.pythons("3.6.0")
+    @pytest.mark.asdf_error("where", 42, "Unknown error")
     def test_asdf_which_error(self, asdf, LOG):
         with pytest.raises(plugin.AsdfError):
             plugin.tox_get_python_executable(EnvConfig())
         LOG.error.assert_called_once()
 
     def test_basepython_is_not_python(self):
-        envconfig = EnvConfig('*TEST*')
+        envconfig = EnvConfig("*TEST*")
         assert plugin.tox_get_python_executable(envconfig) is None
 
     def test_raise_if_no_python(self, asdf):
         with pytest.raises(plugin.AsdfError):
             plugin.tox_get_python_executable(EnvConfig())
 
-    @pytest.mark.all_pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.all_pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_install_python_if_no_python_but_flag(self, asdf, CFG):
         CFG.install = True
         python = plugin.tox_get_python_executable(EnvConfig())
-        assert python == asdf.python_bin('3.6.0')
+        assert python == asdf.python_bin("3.6.0")
 
-    @pytest.mark.all_pythons('2.7.15', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.all_pythons("2.7.15", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_install_python_but_raise_if_no_match(self, asdf, CFG):
         CFG.install = True
         with pytest.raises(plugin.AsdfError):
             plugin.tox_get_python_executable(EnvConfig())
 
-    @pytest.mark.pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_return_python_binary_path(self, asdf):
         python = plugin.tox_get_python_executable(EnvConfig())
-        assert python == asdf.python_bin('3.6.0')
+        assert python == asdf.python_bin("3.6.0")
 
-    @pytest.mark.pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_return_pypy_python_binary_path(self, asdf):
-        envconfig = EnvConfig('pypy')
+        envconfig = EnvConfig("pypy")
         python = plugin.tox_get_python_executable(envconfig)
-        assert python == asdf.python_bin('pypy2.7-6.0.0')
+        assert python == asdf.python_bin("pypy2.7-6.0.0")
 
-    @pytest.mark.pythons('2.7.15', '3.6.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0')
+    @pytest.mark.pythons("2.7.15", "3.6.0", "pypy2.7-6.0.0", "pypy3.8-7.0.0")
     def test_return_pypy3_python_binary_path(self, asdf):
-        envconfig = EnvConfig('pypy3')
+        envconfig = EnvConfig("pypy3")
         python = plugin.tox_get_python_executable(envconfig)
-        assert python == asdf.python_bin('pypy3.5-6.0.0')
+        assert python == asdf.python_bin("pypy3.8-7.0.0")

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -4,64 +4,87 @@ from tox_asdf import plugin
 
 
 def test_only_one_minor():
-    versions = '2.7.0', '3.5.0', '3.6.0', '3.7.0'
-    version = plugin.best_version('3.6', versions)
-    assert version == '3.6.0'
+    versions = "2.7.0", "3.5.0", "3.6.0", "3.7.0"
+    version = plugin.best_version("3.6", versions)
+    assert version == "3.6.0"
 
 
 def test_best_patch():
-    versions = '2.7.0', '3.5.0', '3.6.0', '3.6.1', '3.6.2', '3.6.3', '3.7.0'
-    version = plugin.best_version('3.6', versions)
-    assert version == '3.6.3'
+    versions = "2.7.0", "3.5.0", "3.6.0", "3.6.1", "3.6.2", "3.6.3", "3.7.0"
+    version = plugin.best_version("3.6", versions)
+    assert version == "3.6.3"
 
 
 def test_best_patch_not_alphabetical():
-    versions = '2.7.9', '2.7.17'
-    version = plugin.best_version('2.7', versions)
-    assert version == '2.7.17'
+    versions = "2.7.9", "2.7.17"
+    version = plugin.best_version("2.7", versions)
+    assert version == "2.7.17"
 
 
 def test_multiple_digits():
-    versions = '2.7.0', '3.5.0', '3.6.0', '3.6.1', '3.6.10', '3.6.11', '3.7.0'
-    version = plugin.best_version('3.6', versions)
-    assert version == '3.6.11'
+    versions = "2.7.0", "3.5.0", "3.6.0", "3.6.1", "3.6.10", "3.6.11", "3.7.0"
+    version = plugin.best_version("3.6", versions)
+    assert version == "3.6.11"
 
 
 def test_dev_suffix():
-    versions = '2.7.0', '3.5.0', '3.6-dev', '3.6.0', '3.7.0'
-    version = plugin.best_version('3.6', versions)
-    assert version == '3.6.0'
+    versions = "2.7.0", "3.5.0", "3.6-dev", "3.6.0", "3.7.0"
+    version = plugin.best_version("3.6", versions)
+    assert version == "3.6.0"
 
 
 def test_dev_only():
-    versions = '2.7.0', '3.5.0', '3.6-dev'
-    version = plugin.best_version('3.6', versions)
-    assert version == '3.6-dev'
+    versions = "2.7.0", "3.5.0", "3.6-dev"
+    version = plugin.best_version("3.6", versions)
+    assert version == "3.6-dev"
 
 
-@pytest.mark.parametrize('version', ['2.6', '3.4', '3.8'])
+@pytest.mark.parametrize("version", ["2.6", "3.4", "3.8"])
 def test_not_found(version):
-    versions = '2.7.0', '3.5.0', '3.6.0', '3.6.1', '3.6.2', '3.6.3', '3.7.0'
-    assert plugin.best_version('2.6', versions) is None
+    versions = "2.7.0", "3.5.0", "3.6.0", "3.6.1", "3.6.2", "3.6.3", "3.7.0"
+    assert plugin.best_version("2.6", versions) is None
 
 
 def test_pypy():
-    versions = '2.7.0', '3.6.0', '3.7.0', 'pypy2.7-5.0.0', 'pypy2.7-6.0.0', 'pypy3.5-6.0.0'
-    version = plugin.best_version('pypy2.7', versions)
-    assert version == 'pypy2.7-6.0.0'
+    versions = (
+        "2.7.0",
+        "3.6.0",
+        "3.7.0",
+        "pypy2.7-5.0.0",
+        "pypy2.7-6.0.0",
+        "pypy3.8-7.0.0",
+    )
+    version = plugin.best_version("pypy2.7", versions)
+    assert version == "pypy2.7-6.0.0"
 
 
 def test_pypy_not_found():
-    versions = '2.7.0', '3.6.0', '3.7.0', 'pypy3.5-6.0.0'
-    assert plugin.best_version('pypy2.7', versions) is None
+    versions = "2.7.0", "3.6.0", "3.7.0", "pypy3.8-7.0.0"
+    assert plugin.best_version("pypy2.7", versions) is None
 
 
-def test_pypy3():
-    versions = '2.7.0', '3.6.0', '3.7.0', 'pypy2.7-6.0.0', 'pypy3.5-5.0.0', 'pypy3.5-6.0.0'
-    version = plugin.best_version('pypy3.5', versions)
-    assert version == 'pypy3.5-6.0.0'
+@pytest.mark.parametrize(
+    "version, match",
+    [
+        ("pypy3", "pypy3.8-7.0.0"),
+        ("pypy3.8", "pypy3.8-7.0.0"),
+        ("pypy3.5", "pypy3.5-6.0.0"),
+    ],
+)
+def test_pypy3(version, match):
+    versions = (
+        "2.7.0",
+        "3.6.0",
+        "3.7.0",
+        "pypy2.7-6.0.0",
+        "pypy3.5-6.0.0",
+        "pypy3.8-6.0.0",
+        "pypy3.8-7.0.0",
+    )
+    best = plugin.best_version(version, versions)
+    assert best == match
 
 
 def test_pypy3_not_found():
-    versions = '2.7.0', '3.6.0', '3.7.0', 'pypy2.7-6.0.0'
-    assert plugin.best_version('pypy3.5', versions) is None
+    versions = "2.7.0", "3.6.0", "3.7.0", "pypy2.7-6.0.0"
+    assert plugin.best_version("pypy3.5", versions) is None


### PR DESCRIPTION
- Silence some pytest warnings due to unconfigured markers
- Add a pytest plugin to watch test runs
- Better pypy version selection logic

Fixes #9 